### PR TITLE
Added .tmx to allowed file extensions

### DIFF
--- a/src/com/citrusengine/utils/LevelManager.as
+++ b/src/com/citrusengine/utils/LevelManager.as
@@ -132,7 +132,7 @@ package com.citrusengine.utils {
 			} else {
 				
 				var isXml:String = _levels[_currentIndex][1].substring(_levels[_currentIndex][1].length - 4).toLowerCase();
-				if (isXml == ".xml" || isXml == ".lev") {
+				if (isXml == ".xml" || isXml == ".lev" || isXml == ".tmx") {
 					
 					var urlLoader:URLLoader = new URLLoader();
 					urlLoader.load(new URLRequest(_levels[_currentIndex][1]));


### PR DESCRIPTION
Currently CitrusEngine will throw an error if you try to load TiledMap .tmx file.
