### PR TITLE
Update src/citrus/core/away3d/Away3DCitrusEngine.as

### DIFF
--- a/src/citrus/core/away3d/Away3DCitrusEngine.as
+++ b/src/citrus/core/away3d/Away3DCitrusEngine.as
@@ -23,7 +23,11 @@ package citrus.core.away3d {
 		public function Away3DCitrusEngine() {
 			
 			super();
-			
+		}
+		
+		override protected function handleAddedToStage(e:Event):void 
+		{
+			super.handleAddedToStage(e);
 			stage.addEventListener(Event.RESIZE, _onResize);
 		}
 


### PR DESCRIPTION
Calling stage in the constructor throws null reference error 
