### PR TITLE
Now using exising method in AnimationSequence constructor

### DIFF
--- a/src/citrus/view/starlingview/AnimationSequence.as
+++ b/src/citrus/view/starlingview/AnimationSequence.as
@@ -87,7 +87,7 @@ package citrus.view.starlingview {
 		 * @param textureAtlas a TextureAtlas object with your object's animations you would like to use.
 		 * @param animations an array with the object's animations as a String you would like to pick up.
 		 */
-		public function addTextureAtlasWithAnimations(textureAtlas:TextureAtlas, animations:Array):void {
+		public function addTextureAtlasWithAnimations(textureAtlas:*, animations:Array):void {
 
 			for each (var animation:String in animations) {
 


### PR DESCRIPTION
I wanted to override this method but its not being used in the constructor, let me know what you think!

also added a new method in a99c401
a new removeAllAnimations method so you can clear out the existing MovieClips. I did this so that I can reuse this as a pooled object that just swaps out the previous level's artwork.
