### PR TITLE
Adding a getter so devs can get the current level index. This is really ...

### DIFF
--- a/src/citrus/utils/LevelManager.as
+++ b/src/citrus/utils/LevelManager.as
@@ -186,5 +186,10 @@ package citrus.utils {
 		public function get nameCurrentLevel():String {
 			return currentLevel.nameLevel;
 		}
+
+		public function get currentIndex():uint
+		{
+			return _currentIndex;
+		}
 	}
 }


### PR DESCRIPTION
...helpful if you have several levels based off of the same classes so they cant easily be distinguished other than by index
