### PR TITLE
Fixing bug when trying to remove an object that has been collided with

### DIFF
--- a/src/citrus/objects/platformer/nape/Hero.as
+++ b/src/citrus/objects/platformer/nape/Hero.as
@@ -398,6 +398,8 @@ package citrus.objects.platformer.nape {
 			
 			var collider:NapePhysicsObject = NapeUtils.CollisionGetOther(this, callback);
 			
+			if (collider == null) return;
+			
 			//Remove from ground contacts, if it is one.
 			var index:int = _groundContacts.indexOf(collider.body);
 			if (index != -1)

--- a/src/citrus/physics/nape/NapeContactListener.as
+++ b/src/citrus/physics/nape/NapeContactListener.as
@@ -46,9 +46,10 @@ package citrus.physics.nape {
 			
 			if (a.endContactCallEnabled)
 				a.handleEndContact(interactionCallback);
-				
-			if (b.endContactCallEnabled)
-				b.handleEndContact(interactionCallback);
+			
+			if (b != null) {
+				if (b.endContactCallEnabled) b.handleEndContact(interactionCallback);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Not sure if this is right, but i cant see what has changed and i cant remove items from the level when they get collided with
