### PR TITLE
Fix issue about misunderstood on Starling viewport/stage management

### DIFF
--- a/src/citrus/core/starling/StarlingCitrusEngine.as
+++ b/src/citrus/core/starling/StarlingCitrusEngine.as
@@ -71,8 +71,6 @@ package citrus.core.starling {
 				return;
 			
 			_starling.viewPort.setTo(0, 0, _screenWidth, _screenHeight);
-			_starling.stage.stageWidth = _screenWidth;
-			_starling.stage.stageHeight = _screenHeight;
 		}
 
 		/**

--- a/src/citrus/view/starlingview/StarlingCamera.as
+++ b/src/citrus/view/starlingview/StarlingCamera.as
@@ -1,5 +1,6 @@
 package citrus.view.starlingview {
 
+	import citrus.core.starling.StarlingCitrusEngine;
 	import citrus.math.MathUtils;
 	import citrus.view.ACitrusCamera;
 
@@ -24,7 +25,8 @@ package citrus.view.starlingview {
 		
 		override protected function initialize():void {
 			super.initialize();// setup camera lens normally
-
+			cameraLensWidth = ce.starling.stage.stageWidth;
+			cameraLensHeight = ce.starling.stage.stageHeight;
 			_aabbData = MathUtils.createAABBData(0, 0, cameraLensWidth / _camProxy.scale, cameraLensHeight / _camProxy.scale, _camProxy.rotation, _aabbData);
 			_m = (_viewRoot as starling.display.Sprite).transformationMatrix;
 		}
@@ -495,5 +497,9 @@ package citrus.view.starlingview {
 			_allowRotation = value;
 		}
 		
+		protected function get ce():StarlingCitrusEngine
+		{
+			return _ce as StarlingCitrusEngine;
+		}
 	}
 }


### PR DESCRIPTION
In Starling paradigm, it has no meaning to force starling's stage size on viewport size.

In a resize stage event handler, only viewport must change. In must case, starling stage size is set once and never change. 

Camera lens size must be set according starling's stage size and not it's viewport (which is device dependant).

some resource on viewport and starling's stage sizing
http://wiki.starling-framework.org/manual/multi-resolution_development

"That's simple when you remember that you can set Starling's viewPort and stageWidth/stageHeight properties independently from each other.

The viewPort decides into which area of the screen Starling renders into. It is always specified in pixels.
The stage size decides the size of the coordinate system that is displayed in that viewPort. When your stage width is 320, any object with an x value between 0 and 320 will be within the stage, no matter the size of the viewPort."
