### PR TITLE
Added support for rotated platforms in found in the latest Tiled map editor

### DIFF
--- a/src/citrus/utils/objectmakers/ObjectMakerStarling.as
+++ b/src/citrus/utils/objectmakers/ObjectMakerStarling.as
@@ -2,7 +2,6 @@ package citrus.utils.objectmakers {
 
 	import flash.geom.Point;
 	import flash.geom.Matrix;
-	import flash.geom.Rectangle;
 	import citrus.core.CitrusEngine;
 	import citrus.core.CitrusObject;
 	import citrus.objects.CitrusSprite;


### PR DESCRIPTION
You can now have rotated platforms in the daily build of the Tiled editor
