### PR TITLE
Fixes a bug when using params.view in the SWF (Flash Pro property)

### DIFF
--- a/src/citrus/utils/objectmakers/ObjectMakerStarling.as
+++ b/src/citrus/utils/objectmakers/ObjectMakerStarling.as
@@ -99,7 +99,7 @@ package citrus.utils.objectmakers {
 						}
 					}
 					
-					if (params.view) {
+					if (params.view && !(params.view is Image)) {
 					
 						var suffix:String = params.view.substring(params.view.length - 4).toLowerCase();
 						if (!(suffix == ".swf" || suffix == ".png" || suffix == ".gif" || suffix == ".jpg")) {


### PR DESCRIPTION
If the params.view was already defined in the SWF using e.g. Flash Pro, and the swf is re-used instead of re-loaded (essential for IOS), the params.view property is no longer a String on the 2nd use (e.g. restart level): It is already an Image object. This caused ObjectMakerStarling to crash here, as params view.length is not defined on an Image object.
