### PR TITLE
Bugfix: StarlingTileSystem crashed when using ATF-Images

### DIFF
--- a/src/citrus/view/starlingview/StarlingTileSystem.as
+++ b/src/citrus/view/starlingview/StarlingTileSystem.as
@@ -179,7 +179,7 @@ package citrus.view.starlingview {
 							if (atf) {
 								
 								// load in as bytearray
-								var byteArray:ByteArray = new row[c] as ByteArray;
+								var byteArray:ByteArray = row[c] as ByteArray;
 								if (byteArray) {
 									
 									tile.myATF = byteArray;


### PR DESCRIPTION
Removed a "new"-keyword from the byteArray-definition. This keyword has
caused the StarlingTileSystem to crash when an ATF-Image is loaded as a
ByteArray.
