### PR TITLE
bugfix: null object reference in the set-method "oneWay"

### DIFF
--- a/src/citrus/objects/platformer/nape/Platform.as
+++ b/src/citrus/objects/platformer/nape/Platform.as
@@ -52,6 +52,11 @@ package citrus.objects.platformer.nape {
 			
 			_oneWay = value;
 			
+			// If the body hasn't been created yet stop here.
+			// The callback type and the listener will be added later by the "createConstraint"-method.
+			if (!_body)
+				return;
+			
 			if (_oneWay && !_preListener)
 			{
 				_preListener = new PreListener(InteractionType.COLLISION, Platform.ONEWAY_PLATFORM, CbType.ANY_BODY, handlePreContact,0,true);


### PR DESCRIPTION
When adding a platform object from a tmx-map then the set-method
"oneWay" of the "Plaform"-class (Nape) tries to add a prelistener and a
callback type to the body object which has not been created at this
point.

This doesn't lead to an exception because the try-catch-construction in
the "setParams"-method of the "CitrusObject" catches it. But this method
is not meant to catch this error and therefore displays a misleading
response (Warning: The parameter OneWay does not exist on [class
platform] ...).

I've changed the code such that the prelistener and callback type will
not be added if the body doesn't exist. The "createConstraint"-method
which is called later in the process already takes care of this
instead.
