### PR TITLE
bugfixes: AVirtualJoystick - threshold calculation, Hero - check for...

### DIFF
--- a/src/citrus/input/controllers/AVirtualJoystick.as
+++ b/src/citrus/input/controllers/AVirtualJoystick.as
@@ -163,8 +163,7 @@ package citrus.input.controllers {
 			_yAxis = _targetPosition.y / _innerradius;
 			
 			// Check registered actions on both axes
-			
-			if (_targetPosition.length <= threshold)
+			if (Math.sqrt((_xAxis * _xAxis) + (_yAxis * _yAxis)) <= threshold)
 				_input.stopActionsOf(this);
 			else
 			{


### PR DESCRIPTION
... "duck" instead for "down"

If I understand the threshold property of AVirtualJoystick correctly it
is supposed to be set between 0 and 1. This means that the normalized
distance to the center (which is also between 0 and 1) has to be used
for comparison. But currently the pixel distance to the center is used
instead which will always be >=1 when the knob is not in the center. As
a consequence the threshold setting currently doesn't affect anything.
I've replaced the pixel distance by the normalized distance in order to
fix this.

I've also noticed that in the hero classes for Box2D and Nape the
"down"-state is used to check if the player character is ducking while
the "duck"-state is used for the animation. On the opposite side the
"jump"-state is used in both cases. While the "down"- and "duck"-state
basically seem do the same here, their initial action-ranges in
AVirtualJoystick are different (same goes for "up" and "jump"). This
currently leads to an asynchronous behavior of the virtual joystick,
because you need to be at 0.8 in order to jump but only -0.3 in order to
duck.
Therefore I've changed the check from "down" to "duck" such that you
need to be at -0.8 in order to duck.
