### PR TITLE
Fixes TiledMap layer ordering in Objectmakers (2D & starling) v2

### DIFF
--- a/src/citrus/utils/objectmakers/ObjectMaker2D.as
+++ b/src/citrus/utils/objectmakers/ObjectMaker2D.as
@@ -1,9 +1,10 @@
 package citrus.utils.objectmakers {
-
+	
 	import citrus.core.CitrusEngine;
 	import citrus.core.CitrusObject;
 	import citrus.core.IState;
 	import citrus.objects.CitrusSprite;
+	import citrus.utils.objectmakers.tmx.TmxLayer;
 	import citrus.utils.objectmakers.tmx.TmxMap;
 	import citrus.utils.objectmakers.tmx.TmxObject;
 	import citrus.utils.objectmakers.tmx.TmxObjectGroup;
@@ -15,8 +16,7 @@ package citrus.utils.objectmakers {
 	import flash.geom.Point;
 	import flash.geom.Rectangle;
 	import flash.utils.getDefinitionByName;
-
-
+	
 	/**
 	 * The ObjectMaker is a factory utility class for quickly and easily batch-creating a bunch of CitrusObjects.
 	 * Usually the ObjectMaker is used if you laid out your level in a level editor or an XML file.
@@ -27,10 +27,10 @@ package citrus.utils.objectmakers {
 	 * by your level editor.</p>
 	 */
 	public class ObjectMaker2D {
-
+		
 		public function ObjectMaker2D() {
 		}
-
+		
 		/**
 		 * You can pass a custom-created MovieClip object into this method to auto-create CitrusObjects.
 		 * This method looks at all the children of the MovieClip you passed in, and creates a CitrusObject with the
@@ -66,51 +66,53 @@ package citrus.utils.objectmakers {
 				if (child) {
 					if (!child.className)
 						continue;
-
+					
 					var objectClass:Class = getDefinitionByName(child.className) as Class;
 					var params:Object = {};
-
+					
 					if (child.params)
 						params = child.params;
-
+					
 					params.x = child.x;
 					params.y = child.y;
-
+					
 					// We need to unrotate the object to get its true width/height. Then rotate it back.
 					var rotation:Number = child.rotation;
 					child.rotation = 0;
 					params.width = child.width;
 					params.height = child.height;
 					child.rotation = rotation;
-
+					
 					params.rotation = child.rotation;
-
+					
 					// Adding properties from the component inspector
 					for (var metatags:String in child) {
 						if (metatags != "componentInspectorSetting" && metatags != "className") {
 							params[metatags] = child[metatags];
 						}
 					}
-
+					
 					var object:CitrusObject = new objectClass(child.name, params);
 					a.push(object);
 				}
 			}
-
+			
 			if (addToCurrentState) {
 				var ce:CitrusEngine = CitrusEngine.getInstance();
-				for each (object in a) ce.state.add(object);
+				for each (object in a)
+					ce.state.add(object);
 			}
-
+			
 			return a;
 		}
-
+		
 		/**
 		 * The Citrus Engine supports <a href="http://www.mapeditor.org/">the Tiled Map Editor</a>.
-		 * <p>It supports different layers, objects creation and a Tilesets.</p>
+		 * <p>It supports different layers, objects creation and Tilesets.</p>
 		 *
 		 * <p>You can add properties inside layers (group, parallax...), they are processed as Citrus Sprite.</p>
-		 *
+		 * <p>Polygons are supported but must be drawn clockwise in TiledMap editor to work correctly.</p>
+		 * 
 		 * <p>For the objects, you can add their name and don't forget their types : package name + class name.
 		 * It also supports properties.</p>
 		 * @param levelXML the TMX provided by the Tiled Map Editor software, convert it into an xml before.
@@ -120,208 +122,205 @@ package citrus.utils.objectmakers {
 		 * @see CitrusObject
 		 */
 		public static function FromTiledMap(levelXML:XML, images:Array, addToCurrentState:Boolean = true):Array {
-
+			var objects:Array = [];
+			var map:TmxMap = new TmxMap(levelXML);
+			
+			for each(var layer:Object in map.layers_ordered) {
+				if (layer is TmxLayer) {
+					addTiledLayer(map, layer as TmxLayer, images, objects);
+				}else if (layer is TmxObjectGroup) {
+					addTiledObjectgroup(layer as TmxObjectGroup, objects);
+				}else {
+					throw new Error('Found layer type not supported.');
+				}
+			}		
+			
+			const ce:CitrusEngine = CitrusEngine.getInstance();
+			if (addToCurrentState) {
+				for each (var object:CitrusObject in objects) {
+					ce.state.add(object);
+				}
+			}
+			
+			return objects;
+		}
+		
+		static private function addTiledLayer(map:TmxMap, layer:TmxLayer, images:Array, objects:Array):void {
 			// Bits on the far end of the 32-bit global tile ID are used for tile flags
-			const FLIPPED_DIAGONALLY_FLAG:uint   = 0x20000000;
-			const FLIPPED_VERTICALLY_FLAG:uint   = 0x40000000;
+			const FLIPPED_DIAGONALLY_FLAG:uint = 0x20000000;
+			const FLIPPED_VERTICALLY_FLAG:uint = 0x40000000;
 			const FLIPPED_HORIZONTALLY_FLAG:uint = 0x80000000;
 			const FLIPPED_FLAGS_MASK:uint = ~(FLIPPED_HORIZONTALLY_FLAG | FLIPPED_VERTICALLY_FLAG | FLIPPED_DIAGONALLY_FLAG);
 			const _90degInRad:Number = Math.PI * 0.5;
-		
-			var ce:CitrusEngine = CitrusEngine.getInstance();
+			
 			var params:Object;
-
-			var objects:Array = [];
-
-			var tmx:TmxMap = new TmxMap(levelXML);
-
+			
 			var bmp:Bitmap;
-			var layerBmp:BitmapData;
 			var useBmpSmoothing:Boolean;
-
-			var mapTiles:Array;
-
-			var tileRect:Rectangle = new Rectangle;
-			tileRect.width = tmx.tileWidth;
-			tileRect.height = tmx.tileHeight;
-
-			var flipMatrix:Matrix = new Matrix;
-			var flipBmp:BitmapData = new BitmapData(tmx.tileWidth, tmx.tileHeight, true, 0);
-			var flipBmpRect:Rectangle = new Rectangle(0, 0, tmx.tileWidth, tmx.tileHeight);
 			
-			var tileDestInLayer:Point = new Point;
+			const tileRect:Rectangle = new Rectangle;
+			tileRect.width = map.tileWidth;
+			tileRect.height = map.tileHeight;
 			
-			var mapTilesX:uint, mapTilesY:uint;
+			const mapTiles:Array = layer.tileGIDs;
+			const rows:uint = mapTiles.length;
+			var columns:uint;
 			
+			const flipMatrix:Matrix = new Matrix;
+			const flipBmp:BitmapData = new BitmapData(map.tileWidth, map.tileHeight, true, 0);
+			const flipBmpRect:Rectangle = new Rectangle(0, 0, map.tileWidth, map.tileHeight);
+			
+			const tileDestInLayer:Point = new Point;
 			var pathSplit:Array;
 			var tilesetImageName:String;
 			
-			// working on each Tiled drawing layer
+			const layerBmp:BitmapData = new BitmapData(map.width * map.tileWidth, map.height * map.tileHeight, true, 0);
 			
-			for (var layer_num:uint = 0; layer_num < tmx.layers_ordered.length; ++layer_num) {
+			for each (var tileSet:TmxTileSet in map.tileSets) {
 				
-				var layer:String = tmx.layers_ordered[layer_num];
-				mapTiles = tmx.getLayer(layer).tileGIDs;
-
-				mapTilesX = mapTiles.length;
-
-				layerBmp = new BitmapData(tmx.width * tmx.tileWidth, tmx.height * tmx.tileHeight, true, 0);
-
-				for each (var tileSet:TmxTileSet in tmx.tileSets) {
+				pathSplit = tileSet.imageSource.split("/");
+				tilesetImageName = pathSplit[pathSplit.length - 1];
+				
+				for each (var image:Bitmap in images) {
 					
-					pathSplit = tileSet.imageSource.split("/");
-					tilesetImageName  = pathSplit[pathSplit.length - 1];
-
-					for each (var image:Bitmap in images) {
-						
-						var flag:Boolean = false;
-						
-						if (tilesetImageName == image.name) {
-							flag = true;
-							bmp = image;
-							break;
-						}
+					var flag:Boolean = false;
+					
+					if (tilesetImageName == image.name) {
+						flag = true;
+						bmp = image;
+						break;
 					}
+				}
+				
+				if (!flag || bmp == null) {
+					throw new Error("ObjectMaker didn't find an image name corresponding to the tileset imagesource name: " + tileSet.imageSource + ", add its name to your bitmap.");
+				}
+				
+				useBmpSmoothing ||= bmp.smoothing;
+				
+				tileSet.image = bmp.bitmapData;
+				
+				for (var layerRow:uint = 0; layerRow < rows; ++layerRow) {
 					
-					if (!flag || bmp == null)
-						throw new Error("ObjectMaker didn't find an image name corresponding to the tileset imagesource name: " + tileSet.imageSource + ", add its name to your bitmap.");
+					columns = mapTiles[layerRow].length;
 					
-					useBmpSmoothing ||= bmp.smoothing;
-					
-					tileSet.image = bmp.bitmapData;
-
-					for (var layerCol:uint = 0; layerCol < mapTilesX; ++layerCol) {
-
-						mapTilesY = mapTiles[layerCol].length;
-
-						for (var layerRow:uint = 0; layerRow < mapTilesY; ++layerRow) {
-
-							var tileGID:uint = mapTiles[layerCol][layerRow];
+					for (var layerColumn:uint = 0; layerColumn < columns; ++layerColumn) {
 						
-							// Read out the flags
-							var flipped_horizontally:Boolean = (tileGID & FLIPPED_HORIZONTALLY_FLAG) != 0;
-							var flipped_vertically:Boolean   = (tileGID & FLIPPED_VERTICALLY_FLAG)   != 0;
-							var flipped_diagonally:Boolean   = (tileGID & FLIPPED_DIAGONALLY_FLAG)   != 0;
+						var tileGID:uint = mapTiles[layerRow][layerColumn];
+						
+						// Read out the flags
+						var flipped_horizontally:Boolean = (tileGID & FLIPPED_HORIZONTALLY_FLAG) != 0;
+						var flipped_vertically:Boolean = (tileGID & FLIPPED_VERTICALLY_FLAG) != 0;
+						var flipped_diagonally:Boolean = (tileGID & FLIPPED_DIAGONALLY_FLAG) != 0;
+						
+						// Clear the flags
+						tileGID &= FLIPPED_FLAGS_MASK;
+						
+						if (tileGID != 0) {
 							
-							// Clear the flags
-							tileGID &= FLIPPED_FLAGS_MASK;
+							var tilemapRow:int = (tileGID - 1) / tileSet.numCols;
+							var tilemapCol:int = (tileGID - 1) % tileSet.numCols;
 							
-							if (tileGID != 0) {
+							tileRect.x = tilemapCol * map.tileWidth;
+							tileRect.y = tilemapRow * map.tileHeight;
+							
+							tileDestInLayer.x = layerColumn * map.tileWidth;
+							tileDestInLayer.y = layerRow * map.tileHeight;
+
+							// Handle flipped tiles
+							if (flipped_diagonally || flipped_horizontally || flipped_vertically) {
 								
-								var tilemapRow:int = (tileGID - 1) / tileSet.numCols;
-								var tilemapCol:int = (tileGID - 1) % tileSet.numCols;
+								// We will flip the tilemap image using the center of the current tile
+								var tileCenterX:Number = tileRect.x + tileRect.width * 0.5;
+								var tileCenterY:Number = tileRect.y + tileRect.height * 0.5;
 								
-								tileRect.x = tilemapCol * tmx.tileWidth;
-								tileRect.y = tilemapRow * tmx.tileHeight;
+								flipMatrix.identity();
+								flipMatrix.translate(-tileCenterX, -tileCenterY);
 								
-								tileDestInLayer.x = layerRow * tmx.tileWidth;	// FIXME: this is weird.   "Row * tileWitdh" and "Col * tileHeight"?
-								tileDestInLayer.y = layerCol * tmx.tileHeight;	// it seems the correct is "Col * tileWitdh" and "Row * tileHeight"
-																				// But why it does not work if we change? The problem must be in "mapTilesX" and "mapTilesY" or "mapTiles[layerCol][layerRow]"
-								// Handle flipped tiles
-								
-								if (flipped_diagonally || flipped_horizontally || flipped_vertically)
-								{
-									// We will flip the tilemap image using the center of the current tile
-									
-									var tileCenterX:Number = tileRect.x + tileRect.width  * 0.5;
-									var tileCenterY:Number = tileRect.y + tileRect.height * 0.5;
-									
-									flipMatrix.identity();
-									flipMatrix.translate(-tileCenterX, -tileCenterY);
-									
-									if (flipped_diagonally)
-									{
-										if (flipped_horizontally)
-										{
-											flipMatrix.rotate(_90degInRad);
-											if (flipped_vertically)
-												flipMatrix.scale(1, -1);
-										}
-										else
-										{
-											flipMatrix.rotate(-_90degInRad);
-											if (!flipped_vertically)
-												flipMatrix.scale(1, -1);
-										}
-									}
-									else
-									{
-										if (flipped_horizontally)
-											flipMatrix.scale(-1, 1);
-											
-										if (flipped_vertically)
+								if (flipped_diagonally) {
+									if (flipped_horizontally) {
+										flipMatrix.rotate(_90degInRad);
+										if (flipped_vertically) {
 											flipMatrix.scale(1, -1);
+										}
+									} else {
+										flipMatrix.rotate(-_90degInRad);
+										if (!flipped_vertically) {
+											flipMatrix.scale(1, -1);
+										}
+									}
+								} else {
+									if (flipped_horizontally) {
+										flipMatrix.scale(-1, 1);
 									}
 									
-									flipMatrix.translate(tileCenterX, tileCenterY);
-									flipMatrix.translate(-tileRect.x, -tileRect.y);
-									
-									// clear the buffer and draw
-									flipBmp.fillRect(flipBmpRect, 0);
-									flipBmp.draw(bmp.bitmapData, flipMatrix, null, null, flipBmpRect);
-									
-									layerBmp.copyPixels(flipBmp, flipBmpRect, tileDestInLayer);
+									if (flipped_vertically) {
+										flipMatrix.scale(1, -1);
+									}
 								}
-								else
-								{
-									layerBmp.copyPixels(bmp.bitmapData, tileRect, tileDestInLayer);
-								}
+								
+								flipMatrix.translate(tileCenterX, tileCenterY);
+								flipMatrix.translate(-tileRect.x, -tileRect.y);
+								
+								// clear the buffer and draw
+								flipBmp.fillRect(flipBmpRect, 0);
+								flipBmp.draw(bmp.bitmapData, flipMatrix, null, null, flipBmpRect);
+								
+								layerBmp.copyPixels(flipBmp, flipBmpRect, tileDestInLayer);
+							} else {
+								layerBmp.copyPixels(bmp.bitmapData, tileRect, tileDestInLayer);
 							}
 						}
 					}
 				}
-				
-				var bmpFinal:Bitmap = new Bitmap(layerBmp);
-				bmpFinal.smoothing = useBmpSmoothing;
-				
-				params = {};
-				params.view = bmpFinal;
-
-				for (var param:String in tmx.getLayer(layer).properties)
-					params[param] = tmx.getLayer(layer).properties[param];
-
-				objects.push(new CitrusSprite(layer, params));
 			}
-
+			
+			var bmpFinal:Bitmap = new Bitmap(layerBmp);
+			bmpFinal.smoothing = useBmpSmoothing;
+			
+			params = {};
+			params.view = bmpFinal;
+			
 			flipBmp.dispose();
-
+			
+			for (var param:String in layer.properties) {
+				params[param] = layer.properties[param];
+			}
+			
+			objects.push(new CitrusSprite(layer.name, params));
+		}
+		
+		static private function addTiledObjectgroup(group:TmxObjectGroup, objects:Array):void {
 			var objectClass:Class;
 			var object:CitrusObject;
-
-			for each (var group:TmxObjectGroup in tmx.objectGroups) {
-
-				for each (var objectTmx:TmxObject in group.objects) {
-
-					objectClass = getDefinitionByName(objectTmx.type) as Class;
-
-					params = {};
-
-					for (param in objectTmx.custom)
-						params[param] = objectTmx.custom[param];
-
-					params.x = objectTmx.x + objectTmx.width * 0.5;
-					params.y = objectTmx.y + objectTmx.height * 0.5;
-					params.width = objectTmx.width;
-					params.height = objectTmx.height;
-					params.rotation = objectTmx.rotation;
-					
-					// Polygon/Polyline support
-					if (objectTmx.shapeType != null) {
-						//params.shapeType = objectTmx.shapeType;
-						params.points = objectTmx.points;
-					}
-
-					object = new objectClass(objectTmx.name, params);
-					objects.push(object);
+			var params:Object;
+			
+			for each (var objectTmx:TmxObject in group.objects) {
+				
+				objectClass = getDefinitionByName(objectTmx.type) as Class;
+				
+				params = {};
+				
+				for (var param:String in objectTmx.custom) {
+					params[param] = objectTmx.custom[param];
 				}
+				
+				params.x = objectTmx.x + objectTmx.width * 0.5;
+				params.y = objectTmx.y + objectTmx.height * 0.5;
+				params.width = objectTmx.width;
+				params.height = objectTmx.height;
+				params.rotation = objectTmx.rotation;
+				
+				// Polygon/Polyline support
+				if (objectTmx.points != null) {
+					params.points = objectTmx.points;
+				}
+				
+				object = new objectClass(objectTmx.name, params);
+				objects.push(object);
 			}
-
-			if (addToCurrentState)
-				for each (object in objects) ce.state.add(object);
-
-			return objects;
 		}
-
+		
 		/**
 		 * This batch-creates CitrusObjects from an XML file generated by the level editor GLEED2D. If you would like to
 		 * use GLEED2D as a level editor for your Citrus Engine game, call this function to parse your GLEED2D level.
@@ -368,7 +367,7 @@ package citrus.utils.objectmakers {
 					// Top for primitives, center for textures
 					var y:Number = itemXML.Position.Y.toString();
 					// Left for primitives, center for textures
-
+					
 					// See if this object has a texture
 					var viewString:String = itemXML.texture_filename.toString();
 					if (viewString != "") {
@@ -376,7 +375,7 @@ package citrus.utils.objectmakers {
 						var originX:Number = itemXML.Origin.X.toString();
 						var originY:Number = itemXML.Origin.Y.toString();
 						var rotation:Number = Number(itemXML.Rotation.toString()) * 180 / Math.PI;
-						object = {x:x, y:y, width:originX * 2, height:originY * 2, rotation:rotation, registration:"center"};
+						object = {x: x, y: y, width: originX * 2, height: originY * 2, rotation: rotation, registration: "center"};
 						viewString = Replace(viewString, "\\", "/");
 						// covert backslashes to forward slashes
 						object.view = viewString;
@@ -384,14 +383,14 @@ package citrus.utils.objectmakers {
 						// Create known params for a GLEED2D "primitive"
 						var width:Number = itemXML.Width.toString();
 						var height:Number = itemXML.Height.toString();
-
-						object = {x:x + (width / 2), y:y + (height / 2), width:width, height:height};
+						
+						object = {x: x + (width / 2), y: y + (height / 2), width: width, height: height};
 					}
-
+					
 					// Covert GLEED layer index to a property on the object.
 					if (layerIndexProperty)
 						object[layerIndexProperty] = layerIndex;
-
+					
 					// Add the custom properties
 					var className:String = defaultClassName;
 					for each (var customPropXML:XML in itemXML.CustomProperties.Property) {
@@ -400,20 +399,20 @@ package citrus.utils.objectmakers {
 						else
 							object[customPropXML.@Name.toString()] = customPropXML.string.toString();
 					}
-
+					
 					// Make the CitrusObject and add it to the current state.
 					var citrusClass:Class = getDefinitionByName(className) as Class;
 					var citrusObject:CitrusObject = new citrusClass(objectName, object);
 					if (addToCurrentState)
 						ce.state.add(citrusObject);
-
+					
 					items.push(citrusObject);
 				}
 				layerIndex++;
 			}
 			return items;
 		}
-
+		
 		/**
 		 * This function batch-creates Citrus Engine game objects from an XML file generated by the Level Architect.
 		 * If you are using the Level Architect as your level editor, call this function to parse the objects in
@@ -425,14 +424,13 @@ package citrus.utils.objectmakers {
 		 */
 		public static function FromLevelArchitect(levelData:XML, addToCurrentState:Boolean = true):Array {
 			var array:Array = [];
-
+			
 			var state:IState = CitrusEngine.getInstance().state;
 			for each (var objectXML:XML in levelData.CitrusObject) {
 				var params:Object = {};
 				for each (var paramXML:XML in objectXML.Property) {
 					params[paramXML.@name] = paramXML.toString();
-				}
-				var className:String = objectXML.@className;
+				}var className:String = objectXML.@className;
 				try {
 					var theClass:Class = getDefinitionByName(className) as Class;
 				} catch (e:Error) {
@@ -447,10 +445,10 @@ package citrus.utils.objectmakers {
 				if (addToCurrentState)
 					state.add(theObject);
 			}
-
+			
 			return array;
 		}
-
+		
 		private static function Replace(str:String, fnd:String, rpl:String):String {
 			return str.split(fnd).join(rpl);
 		}

--- a/src/citrus/utils/objectmakers/ObjectMakerStarling.as
+++ b/src/citrus/utils/objectmakers/ObjectMakerStarling.as
@@ -1,5 +1,6 @@
 package citrus.utils.objectmakers {
-
+	
+	import citrus.utils.objectmakers.tmx.TmxLayer;
 	import flash.geom.Point;
 	import flash.geom.Matrix;
 	import citrus.core.CitrusEngine;
@@ -10,27 +11,27 @@ package citrus.utils.objectmakers {
 	import citrus.utils.objectmakers.tmx.TmxObjectGroup;
 	import citrus.utils.objectmakers.tmx.TmxPropertySet;
 	import citrus.utils.objectmakers.tmx.TmxTileSet;
-
+	
 	import starling.display.Image;
 	import starling.display.QuadBatch;
 	import starling.textures.Texture;
 	import starling.textures.TextureAtlas;
 	import starling.utils.Color;
-
+	
 	import flash.display.MovieClip;
 	import flash.utils.getDefinitionByName;
-
+	
 	/**
 	 * The ObjectMaker is a factory utility class for quickly and easily batch-creating a bunch of CitrusObjects.
 	 * Usually the ObjectMaker is used if you laid out your level in a level editor or an XML file.
 	 * Pass in your layout object (SWF, XML, or whatever else is supported in the future) to the appropriate method,
 	 * and the method will return an array of created CitrusObjects.
-	 * 
+	 *
 	 * <p>The methods within the ObjectMaker should be called according to what kind of layout file that was created
 	 * by your level editor.</p>
 	 */
 	public class ObjectMakerStarling {
-
+		
 		public function ObjectMakerStarling() {
 		}
 		
@@ -38,30 +39,30 @@ package citrus.utils.objectmakers {
 		 * You can pass a custom-created MovieClip object into this method to auto-create CitrusObjects.
 		 * This method looks at all the children of the MovieClip you passed in, and creates a CitrusObject with the
 		 * x, y, width, height, name, and rotation of the of MovieClip.
-		 * 
-		 * <p>You may use the powerful Inspectable metadata tag : in your fla file, add the path to the libraries and 
-		 * the swcs. Then create your MovieClip, right click on it and convert as a component. Inform the package and class. 
+		 *
+		 * <p>You may use the powerful Inspectable metadata tag : in your fla file, add the path to the libraries and
+		 * the swcs. Then create your MovieClip, right click on it and convert as a component. Inform the package and class.
 		 * You will have access to all its properties.</p>
-		 * 
+		 *
 		 * <p>You can also add properties directly in your MovieClips, follow this step :</p>
-		 * 
+		 *
 		 * <p>In order for this to properly create a CitrusObject from a MovieClip, the MovieClip needs to have a variable
 		 * called <code>classPath</code> on it, which will provide, in String form, the full
 		 * package and class name of the Citrus Object that it is supposed to create (such as "myGame.MyHero"). You can specify
 		 * this in frame 1 of the MovieClip asset in Flash.</p>
-		 * 
+		 *
 		 * <p>You can also initialize your CitrusObject's parameters by creating a "params" variable (of type Object)
 		 * on your MovieClip. The "params" object will be passed into the newly created CitrusObject.</p>
-		 * 
+		 *
 		 * <p>So, within the first frame of each child-MovieClip of the "layout" MovieClip,
 		 * you should specify something like the following:</p>
-		 * 
+		 *
 		 * <p><code>var classPath="citrus.objects.platformer.Hero";</code></p>
-		 * 
+		 *
 		 * <p><code>var params={view: "Patch.swf", jumpHeight: 14};</code></p>
-		 * 
+		 *
 		 * <p>This Starling version enables you to use a String for the view which is a texture name coming from your texture atlas.</p>
-		 * 
+		 *
 		 * @param textureAtlas A TextureAtlas or an AssetManager object containing textures which are used in your level maker.
 		 */
 		public static function FromMovieClip(mc:MovieClip, textureAtlas:*, addToCurrentState:Boolean = true):Array {
@@ -73,25 +74,25 @@ package citrus.utils.objectmakers {
 				if (child) {
 					if (!child.className)
 						continue;
-
+					
 					var objectClass:Class = getDefinitionByName(child.className) as Class;
 					var params:Object = {};
-
+					
 					if (child.params)
 						params = child.params;
-
+					
 					params.x = child.x;
 					params.y = child.y;
-
+					
 					// We need to unrotate the object to get its true width/height. Then rotate it back.
 					var rotation:Number = child.rotation;
 					child.rotation = 0;
 					params.width = child.width;
 					params.height = child.height;
 					child.rotation = rotation;
-
+					
 					params.rotation = child.rotation;
-
+					
 					// Adding properties from the component inspector
 					for (var metatags:String in child) {
 						if (metatags != "componentInspectorSetting" && metatags != "className") {
@@ -100,7 +101,7 @@ package citrus.utils.objectmakers {
 					}
 					
 					if (params.view && !(params.view is Image)) {
-					
+						
 						var suffix:String = params.view.substring(params.view.length - 4).toLowerCase();
 						if (!(suffix == ".swf" || suffix == ".png" || suffix == ".gif" || suffix == ".jpg")) {
 							if (textureAtlas)
@@ -109,305 +110,301 @@ package citrus.utils.objectmakers {
 								throw new Error("ObjectMakerStarling FromMovieClip function needs a TextureAtlas or a reference to an AssetManager!");
 						}
 					}
-
+					
 					var object:CitrusObject = new objectClass(child.name, params);
 					a.push(object);
 				}
 			}
-
+			
 			if (addToCurrentState) {
 				var ce:CitrusEngine = CitrusEngine.getInstance();
-				for each (object in a) ce.state.add(object);
+				for each (object in a)
+					ce.state.add(object);
 			}
-
+			
 			return a;
 		}
-
+		
 		/**
 		 * The Citrus Engine supports <a href="http://www.mapeditor.org/">the Tiled Map Editor</a>.
 		 * <p>It supports different layers, objects creation and a Tilesets.</p>
-		 * 
+		 *
 		 * <p>You can add properties inside layers (group, parallax...), they are processed as Citrus Sprite.</p>
-		 * 
-		 * <p>For the objects, you can add their name and don't forget their types : package name + class name. 
+		 * <p>Polygons are supported but must be drawn clockwise in TiledMap editor to work correctly.</p>
+		 *
+		 * <p>For the objects, you can add their name and don't forget their types : package name + class name.
 		 * It also supports properties.</p>
 		 * @param levelXML the TMX provided by the Tiled Map Editor software, convert it into an xml before.
 		 * @param atlas an atlas or a reference to an AssetManager which represent the different tiles, you must name each tile with the corresponding texture name.
 		 */
 		public static function FromTiledMap(levelXML:XML, atlas:*, addToCurrentState:Boolean = true):Array {
-
-			var ce:CitrusEngine = CitrusEngine.getInstance();
-			var params:Object;
-
 			var objects:Array = [];
-
 			var tmx:TmxMap = new TmxMap(levelXML);
-
-			var citrusSprite:CitrusSprite;
-
-			var mapTiles:Array;
-			var mapTilesX:uint, mapTilesY:uint;
+			
+			for each (var layer:Object in tmx.layers_ordered) {
+				if (layer is TmxLayer) {
+					addTiledLayer(tmx, atlas, layer as TmxLayer, objects);
+				} else if (layer is TmxObjectGroup) {
+					addTiledObjectgroup(tmx, atlas, layer as TmxObjectGroup, objects);
+				}
+			}
+			
+			const ce:CitrusEngine = CitrusEngine.getInstance();
+			if (addToCurrentState)
+				for each (var object:CitrusObject in objects)
+					ce.state.add(object);
+			
+			return objects;
+		}
+		
+		static private function addTiledLayer(tmx:TmxMap, atlas:*, layer:TmxLayer, objects:Array):void {
+			var mapTiles:Array = layer.tileGIDs;
+			var mapTilesX:uint = mapTiles.length;
+			var mapTilesY:uint;
 			
 			var tileSet:TmxTileSet;
 			var tileProps:TmxPropertySet;
 			var name:String;
 			var texture:Texture;
 			
-			for (var layer_num:uint = 0; layer_num < tmx.layers_ordered.length; ++layer_num) {
+			var qb:QuadBatch = new QuadBatch();
+			
+			for (var i:uint = 0; i < mapTilesX; ++i) {
 				
-				var layer:String = tmx.layers_ordered[layer_num];
-				mapTiles = tmx.getLayer(layer).tileGIDs;
-
-				mapTilesX = mapTiles.length;
-
-				var qb:QuadBatch = new QuadBatch();
-
-					for (var i:uint = 0; i < mapTilesX; ++i) {
-
-						mapTilesY = mapTiles[i].length;
-
-						for (var j:uint = 0; j < mapTilesY; ++j) {
-
-							if (mapTiles[i][j] != 0) {
-								
-								var tileID:uint = mapTiles[i][j];
-								
-								for each (tileSet in tmx.tileSets) {
-									tileProps = tileSet.getProperties(tileID - tileSet.firstGID);
-									if (tileProps != null) break;
-								}
-								name = tileProps["name"];
-								
-								texture = atlas.getTexture(name);
-
-								var image:Image = new Image(texture);
-								image.x = j * tmx.tileWidth;
-								image.y = i * tmx.tileHeight;
-
-								qb.addImage(image);
-							}
+				mapTilesY = mapTiles[i].length;
+				
+				for (var j:uint = 0; j < mapTilesY; ++j) {
+					
+					if (mapTiles[i][j] != 0) {
+						
+						var tileID:uint = mapTiles[i][j];
+						
+						for each (tileSet in tmx.tileSets) {
+							tileProps = tileSet.getProperties(tileID - tileSet.firstGID);
+							if (tileProps != null)
+								break;
 						}
+						name = tileProps["name"];
+						
+						texture = atlas.getTexture(name);
+						
+						var image:Image = new Image(texture);
+						image.x = j * tmx.tileWidth;
+						image.y = i * tmx.tileHeight;
+						
+						qb.addImage(image);
+					}
 				}
-
-				params = {};
-
-				params.view = qb;
-
-				for (var param:String in tmx.getLayer(layer).properties)
-					params[param] = tmx.getLayer(layer).properties[param];
-
-				citrusSprite = new CitrusSprite(layer, params);
-				objects.push(citrusSprite);
 			}
-
+			
+			var params:Object = {};
+			params.view = qb;
+			
+			for (var param:String in layer.properties) {
+				params[param] = layer.properties[param];
+			}
+			
+			objects.push(new CitrusSprite(layer.name, params));
+		}
+		
+		static private function addTiledObjectgroup(tmx:TmxMap, atlas:*, group:TmxObjectGroup, objects:Array):void {
 			var objectClass:Class;
 			var object:CitrusObject;
+			
+			var tileSet:TmxTileSet;
+			var tileProps:TmxPropertySet;
+			var name:String;
+			
 			var mtx:Matrix = new Matrix();
 			var pt:Point = new Point();
 			var newLoc:Point;
-			var group:TmxObjectGroup;
 			var objectTmx:TmxObject;
 			
-			for each (group in tmx.objectGroups) {
-
-				for each (objectTmx in group.objects) {
-
-					objectClass = getDefinitionByName(objectTmx.type) as Class;
-
-					params = {};
-
-					for (param in objectTmx.custom)
-						params[param] = objectTmx.custom[param];
-
-					params.x = objectTmx.x + objectTmx.width * 0.5;
-					params.y = objectTmx.y + objectTmx.height * 0.5;
-					params.width = objectTmx.width;
-					params.height = objectTmx.height;
-					params.rotation = objectTmx.rotation;
+			for each (objectTmx in group.objects) {
+				
+				objectClass = getDefinitionByName(objectTmx.type) as Class;
+				var params:Object = {};
+				
+				for (var param:String in objectTmx.custom) {
+					params[param] = objectTmx.custom[param];
+				}
+				
+				params.x = objectTmx.x + objectTmx.width * 0.5;
+				params.y = objectTmx.y + objectTmx.height * 0.5;
+				params.width = objectTmx.width;
+				params.height = objectTmx.height;
+				params.rotation = objectTmx.rotation;
+				
+				if (params.rotation != 0) {
+					mtx.identity();
+					mtx.rotate(objectTmx.rotation * Math.PI / 180); 
+					pt.setTo(objectTmx.width / 2, objectTmx.height / 2);
+					newLoc = mtx.transformPoint(pt);
+					params.x = objectTmx.x + newLoc.x;
+					params.y = objectTmx.y + newLoc.y;
+				}
+				
+				if (objectTmx.custom && objectTmx.custom["view"]) {
+					params.view = atlas.getTexture(objectTmx.custom["view"]);
 					
-					if (params.rotation != 0) {
-						mtx.identity();
-						mtx.rotate(objectTmx.rotation * Math.PI / 180); 
-						pt.setTo(objectTmx.width / 2, objectTmx.height / 2);
-						newLoc = mtx.transformPoint(pt);
-						params.x = objectTmx.x + newLoc.x;
-						params.y = objectTmx.y + newLoc.y;
+				} else if (objectTmx.gid != 0) { // for handling image objects in Tiled
+					for each (tileSet in tmx.tileSets) {
+						tileProps = tileSet.getProperties(objectTmx.gid - tileSet.firstGID);
+						if (tileProps != null)
+							break;
 					}
+					name = tileProps["name"];
+					params.view = atlas.getTexture(name);
+					params.width = Texture(params.view).frame.width;
+					params.height = Texture(params.view).frame.height;
+					params.x += params.width / 2;
+					params.y -= params.height / 2;
+				}
+				
+				// Polygon/Polyline support
+				if (objectTmx.shapeType != null) {
+					params.shapeType = objectTmx.shapeType;
+					params.points = objectTmx.points;
+				}
+				
+				object = new objectClass(objectTmx.name, params);
+				objects.push(object);
+			}
+		}
+		
+		/**
+		 * This batch-creates CitrusObjects from an XML file generated by the level editor GLEED2D. If you would like to
+		 * use GLEED2D as a level editor for your Citrus Engine game, call this function to parse your GLEED2D level.
+		 *
+		 * <p>When using GLEED2D, there are a few things to note:
+		 * <ul>
+		 * <li> You must add a custom property named 'className' for each object you make, unless it will be of the type
+		 * specified in the <code>defaultClassName</code> parameter. Assign this property a value
+		 * that represents the class that you want that object to be. For example, if you wanted to make a hero, you must
+		 * give your GLEED2D Hero 'className' property the value 'citrus.objects.platformer.Hero'. Don't forget
+		 * to include the package, or the Citrus Engine won't be able to make your object.</li>
+		 * <li> You can shift-click and drag to duplicate GLEED2D objects. This is the easiest way to copy an entire object,
+		 * custom-properties and all.</li>
+		 * <li> Unfortunately, GLEED2D does not support rotating the Rectangle Primitive, this makes GLEED2D difficult to use
+		 * if you plan on using it to layout levels for a platformer with hills. You can, however, specify a custom property
+		 * named "rotation", which will work in Citrus Engine, but not be reflected in GLEED2D.</li>
+		 * <li> GLEED2D does not support SWFs as textures, so any CitrusObjects that will use SWFs as their view should
+		 * be created via a GLEED2D rectangle primitive, then specify the SWF path or MovieClip class name using a custom
+		 * property named 'view'.
+		 * </li>
+		 * </ul>
+		 * </p>
+		 *
+		 * @param levelXML An XML level object created by GLEED2D.
+		 * @param textureAtlas An TextureAtlas that provides all texture within the level. (Note this function supports only single atlas)
+		 * @param addToCurrentState Automatically adds all CitrusObjects that get created to the current state.
+		 * @param layerIndexProperty Gleed's layer indexes will be assigned to the specified property.
+		 * @param defaultClassName If a className custom property is not specified on a GLEED2D asset, this is the default CitrusObject class that gets created.
+		 * @return An array of CitrusObjects. If the <code>addToCurrentState</code> property is false, you will still need to add these to the state.
+		 *
+		 */
+		public static function FromGleed(levelXML:XML, textureAtlas:TextureAtlas, addToCurrentState:Boolean = true, layerIndexProperty:String = "group", defaultClassName:String = "citrus.objects.CitrusSprite"):Array {
+			var objects:Array = [];
+			var citrusObject:CitrusObject;
+			var xsiNS:Namespace = new Namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+			var ce:CitrusEngine = CitrusEngine.getInstance();
+			
+			for each (var layerXML:XML in levelXML.Layers.Layer) // Loop through all layers
+			{
+				var textureItems:Vector.<Image> = new Vector.<Image>;
+				var layer:String = layerXML.@Name.toString();
+				
+				for each (var itemXML:XML in layerXML.Items.Item) // Loop through all items on a layer
+				{
+					var object:Object = {};
+					var objectName:String = itemXML.@Name.toString();
+					var x:Number = itemXML.Position.X.toString();
+					var y:Number = itemXML.Position.Y.toString();
+					var type:String = itemXML.@xsiNS::type.toString();
+					var assetString:String = itemXML.asset_name.toString();
+					var className:String = defaultClassName;
 					
-					if (objectTmx.custom && objectTmx.custom["view"]) {
-						params.view = atlas.getTexture(objectTmx.custom["view"]);
-						
-					} else if (objectTmx.gid != 0) { // for handling image objects in Tiled
-						for each (tileSet in tmx.tileSets) {
-							tileProps = tileSet.getProperties(objectTmx.gid - tileSet.firstGID);
-							if (tileProps != null) break;
+					// Let's add custom properties
+					for each (var customPropXML:XML in itemXML.CustomProperties.Property) {
+						if (customPropXML.@Name.toString() == "className")
+						{
+							className = customPropXML.string.toString();
 						}
-						name = tileProps["name"];
-						params.view = atlas.getTexture(name);
-						params.width = Texture(params.view).frame.width;
-						params.height = Texture(params.view).frame.height;
-						params.x += params.width / 2;
-						params.y -= params.height / 2;
+						else
+						{
+							object[customPropXML.@Name.toString()] = customPropXML.string.toString();
+						}
 					}
 					
-					// Polygon/Polyline support
-					if (objectTmx.shapeType != null) {
-						//params.shapeType = objectTmx.shapeType;
-						params.points = objectTmx.points;
+					// Let's strip the filename from the texturepath. This is going to be the atlas alias for this texture
+					assetString = assetString.substr(assetString.lastIndexOf("\\") + 1, assetString.length);
+					if (assetString)
+						object.assetString = assetString;
+					
+					// If the item is just a TextureItem without any specified class, we will add it to the quadbatch which represents the layer
+					if (className == defaultClassName && type == "TextureItem" && assetString != "") {
+						var originX:Number = itemXML.Origin.X.toString();
+						var originY:Number = itemXML.Origin.Y.toString();
+						var scaleX:Number = itemXML.Scale.X.toString();
+						var scaleY:Number = itemXML.Scale.Y.toString();
+						var rotation:Number = Number(itemXML.Rotation.toString());
+						
+						// Flip
+						var flipHorizontally:String = itemXML.FlipHorizontally.toString();
+						var flipVertically:String = itemXML.FlipVertically.toString();
+						if (flipHorizontally == "true")
+							scaleX *= -1;
+						if (flipVertically == "true")
+							scaleY *= -1;
+						
+						// TintColor
+						var r:int = itemXML.TintColor.R.toString();
+						var g:int = itemXML.TintColor.G.toString();
+						var b:int = itemXML.TintColor.B.toString();
+						var a:int = itemXML.TintColor.A.toString();
+						
+						// Let's create the image that matches the asset string
+						var image:Image = new Image(textureAtlas.getTexture(assetString));
+						image.x = x;
+						image.y = y;
+						image.scaleX = scaleX;
+						image.scaleY = scaleY;
+						image.pivotX = originX;
+						image.pivotY = originY;
+						image.rotation = rotation;
+						image.color = Color.argb(a, r, g, b);
+						
+						// And finally we collect these images for later batching
+						textureItems.push(image);
 					}
-
-					object = new objectClass(objectTmx.name, params);
-					objects.push(object);
+				}
+				
+				// We will bundle all TextureItems into single quadbatch
+				if (textureItems.length > 0) {
+					var qb:QuadBatch = new QuadBatch();
+					
+					for each (image in textureItems) {
+						qb.addImage(image);
+					}
+					
+					var citrusSprite:CitrusSprite = new CitrusSprite(layer, { view: qb });
+					objects.push(citrusSprite);
 				}
 			}
-
-			if (addToCurrentState)
-				for each (object in objects) ce.state.add(object);
-
+			
+			// Finally we will add everything to the state
+			if (addToCurrentState) {
+				for each (citrusObject in objects) {
+					
+					if (citrusObject is CitrusSprite) {
+						citrusSprite = citrusObject as CitrusSprite;
+					}
+					
+					ce.state.add(citrusObject);
+				}
+			}
+			
 			return objects;
-        }
-
-        /**
-         * This batch-creates CitrusObjects from an XML file generated by the level editor GLEED2D. If you would like to
-         * use GLEED2D as a level editor for your Citrus Engine game, call this function to parse your GLEED2D level.
-         *
-         * <p>When using GLEED2D, there are a few things to note:
-         * <ul>
-         * <li> You must add a custom property named 'className' for each object you make, unless it will be of the type
-         * specified in the <code>defaultClassName</code> parameter. Assign this property a value
-         * that represents the class that you want that object to be. For example, if you wanted to make a hero, you must
-         * give your GLEED2D Hero 'className' property the value 'citrus.objects.platformer.Hero'. Don't forget
-         * to include the package, or the Citrus Engine won't be able to make your object.</li>
-         * <li> You can shift-click and drag to duplicate GLEED2D objects. This is the easiest way to copy an entire object,
-         * custom-properties and all.</li>
-         * <li> Unfortunately, GLEED2D does not support rotating the Rectangle Primitive, this makes GLEED2D difficult to use
-         * if you plan on using it to layout levels for a platformer with hills. You can, however, specify a custom property
-         * named "rotation", which will work in Citrus Engine, but not be reflected in GLEED2D.</li>
-         * <li> GLEED2D does not support SWFs as textures, so any CitrusObjects that will use SWFs as their view should
-         * be created via a GLEED2D rectangle primitive, then specify the SWF path or MovieClip class name using a custom
-         * property named 'view'.
-         * </li>
-         * </ul>
-         * </p>
-         *
-         * @param levelXML An XML level object created by GLEED2D.
-         * @param textureAtlas An TextureAtlas that provides all texture within the level. (Note this function supports only single atlas)
-         * @param addToCurrentState Automatically adds all CitrusObjects that get created to the current state.
-         * @param layerIndexProperty Gleed's layer indexes will be assigned to the specified property.
-         * @param defaultClassName If a className custom property is not specified on a GLEED2D asset, this is the default CitrusObject class that gets created.
-         * @return An array of CitrusObjects. If the <code>addToCurrentState</code> property is false, you will still need to add these to the state.
-         *
-         */
-        public static function FromGleed(levelXML:XML, textureAtlas:TextureAtlas, addToCurrentState:Boolean = true, layerIndexProperty:String = "group", defaultClassName:String = "citrus.objects.CitrusSprite"):Array
-        {
-            var objects:Array = [];
-            var citrusObject:CitrusObject;
-            var xsiNS:Namespace = new Namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
-            var ce:CitrusEngine = CitrusEngine.getInstance();
-
-            for each (var layerXML:XML in levelXML.Layers.Layer) // Loop through all layers
-            {
-                var textureItems:Vector.<Image> = new Vector.<Image>;
-                var layer:String = layerXML.@Name.toString();
-
-                for each (var itemXML:XML in layerXML.Items.Item) // Loop through all items on a layer
-                {
-                    var object:Object = {};
-                    var objectName:String = itemXML.@Name.toString();
-                    var x:Number = itemXML.Position.X.toString();
-                    var y:Number = itemXML.Position.Y.toString();
-                    var type:String = itemXML.@xsiNS::type.toString();
-                    var assetString:String = itemXML.asset_name.toString();
-                    var className:String = defaultClassName;
-
-                    // Let's add custom properties
-                    for each (var customPropXML:XML in itemXML.CustomProperties.Property)
-                    {
-                        if (customPropXML.@Name.toString() == "className")
-                        {
-                            className = customPropXML.string.toString();
-                        }
-                        else
-                        {
-                            object[customPropXML.@Name.toString()] = customPropXML.string.toString();
-                        }
-                    }
-
-                    // Let's strip the filename from the texturepath. This is going to be the atlas alias for this texture
-                    assetString = assetString.substr(assetString.lastIndexOf("\\") + 1, assetString.length);
-                    if (assetString)
-                        object.assetString = assetString;
-
-                    // If the item is just a TextureItem without any specified class, we will add it to the quadbatch which represents the layer
-                    if (className == defaultClassName && type == "TextureItem" && assetString != "")
-                    {
-                        var originX:Number = itemXML.Origin.X.toString();
-                        var originY:Number = itemXML.Origin.Y.toString();
-                        var scaleX:Number = itemXML.Scale.X.toString();
-                        var scaleY:Number = itemXML.Scale.Y.toString();
-                        var rotation:Number = Number(itemXML.Rotation.toString());
-
-                        // Flip
-                        var flipHorizontally:String = itemXML.FlipHorizontally.toString();
-                        var flipVertically:String = itemXML.FlipVertically.toString();
-                        if (flipHorizontally == "true")
-                            scaleX *= -1;
-                        if (flipVertically == "true")
-                            scaleY *= -1;
-
-                        // TintColor
-                        var r:int = itemXML.TintColor.R.toString();
-                        var g:int = itemXML.TintColor.G.toString();
-                        var b:int = itemXML.TintColor.B.toString();
-                        var a:int = itemXML.TintColor.A.toString();
-
-                        // Let's create the image that matches the asset string
-                        var image:Image = new Image(textureAtlas.getTexture(assetString));
-                        image.x = x;
-                        image.y = y;
-                        image.scaleX = scaleX;
-                        image.scaleY = scaleY;
-                        image.pivotX = originX;
-                        image.pivotY = originY;
-                        image.rotation = rotation;
-                        image.color = Color.argb(a, r, g, b);
-
-                        // And finally we collect these images for later batching
-                        textureItems.push(image);
-                    }
-                }
-
-                // We will bundle all TextureItems into single quadbatch
-                if (textureItems.length > 0)
-                {
-                    var qb:QuadBatch = new QuadBatch();
-
-                    for each (image in textureItems)
-                    {
-                        qb.addImage(image);
-                    }
-
-                    var citrusSprite:CitrusSprite = new CitrusSprite(layer, { view: qb });
-                    objects.push(citrusSprite);
-                }
-            }
-
-            // Finally we will add everything to the state
-            if (addToCurrentState)
-            {
-                for each (citrusObject in objects)
-                {
-
-                    if (citrusObject is CitrusSprite)
-                    {
-                        citrusSprite = citrusObject as CitrusSprite;
-                    }
-
-                    ce.state.add(citrusObject);
-                }
-            }
-
-            return objects;
-        }
-    }
+		}
+	}
 }

--- a/src/citrus/utils/objectmakers/tmx/TmxLayer.as
+++ b/src/citrus/utils/objectmakers/tmx/TmxLayer.as
@@ -18,6 +18,7 @@ package citrus.utils.objectmakers.tmx {
 		public var height:int;
 		public var opacity:Number;
 		public var visible:Boolean;
+		// tileGIDs[row][column]
 		public var tileGIDs:Array;
 		public var properties:TmxPropertySet = null;
 


### PR DESCRIPTION
Edit: New request since documentation was wrong on first request. Sorry for double request. This also bundles the prior commits to one.

Problem before:
The order of tile layers and object layers (internally called objectgroups) are only considered separately. Object layers will always be in the foreground. This causes problems if objects in an object layer have the view parameter set.
Example: A background object with an image as view will always cover all tiles.

This fix resolves this issue by taking the total order of tile and object layers into account.

As small bonus I also fixed the FIXME in Objectmaker2D (semantics issue).

Tests:
I tested the Objectmaker2D case in my own project and the starling case with the given example from the Citrus-Engine-Examples repository. The ordering of tiles and objects were as defined in the TiledMap editor. This resolved my object view problem.
