### PR TITLE
Update Emitter.as

### DIFF
--- a/src/citrus/objects/common/Emitter.as
+++ b/src/citrus/objects/common/Emitter.as
@@ -3,8 +3,6 @@ package citrus.objects.common
 
 	import citrus.core.CitrusEngine;
 	import citrus.core.CitrusObject;
-	import citrus.view.blittingview.BlittingArt;
-	import citrus.view.blittingview.BlittingView;
 	
 	/**
 	 * An emitter creates particles at a specified rate with specified distribution properties. You can set the emitter's x and y
@@ -156,7 +154,7 @@ package citrus.objects.common
 		{
 			updateCallEnabled = true;
 			
-			super(name, params);
+			super(params);
 			_ce = CitrusEngine.getInstance();
 		}
 		


### PR DESCRIPTION
deleted two unused imports import citrus.view.blittingview.BlittingArt; & import citrus.view.blittingview.BlittingView; 
  the super class only has one parameter