### PR TITLE
update EmitterParticle.as &Path.as  Constructors‘  super();

### DIFF
--- a/src/citrus/core/CitrusEngine.as
+++ b/src/citrus/core/CitrusEngine.as
@@ -114,12 +114,12 @@ package citrus.core {
 			onPlayingChange.add(handlePlayingChange);
 			
 			// on iOS if the physical button is off, mute the sound
-			if ("audioPlaybackMode" in SoundMixer)
+			if ("audioPlaybackMode" in SoundMixer){
 				try { SoundMixer.audioPlaybackMode = "ambient"; }
 					catch(e:ArgumentError) {
 							trace("[CitrusEngine] could not set SoundMixer.audioPlaybackMode to ambient.");
 						}
-			
+			}
 			//Set up console
 			_console = new Console(9); //Opens with tab key by default
 			_console.onShowConsole.add(handleShowConsole);

--- a/src/citrus/objects/common/EmitterParticle.as
+++ b/src/citrus/objects/common/EmitterParticle.as
@@ -12,8 +12,7 @@ package citrus.objects.common
 		
 		public function EmitterParticle(name:String, params:Object = null) 
 		{
-			super(name, params);
-			
+			super(params);
 			if (birthTime == 0)
 				birthTime = new Date().time;
 		}

--- a/src/citrus/objects/common/Path.as
+++ b/src/citrus/objects/common/Path.as
@@ -16,7 +16,7 @@ package citrus.objects.common {
 
         public function Path(name:String, params:Object = null)
         {
-            super(name, params);
+            super(params);
             _nodes = new Vector.<MathVector>;
         }
 			

--- a/src/citrus/physics/APhysicsEngine.as
+++ b/src/citrus/physics/APhysicsEngine.as
@@ -9,6 +9,7 @@ package citrus.physics {
 		
 		protected var _visible:Boolean = false;
 		protected var _touchable:Boolean = false;
+		protected var _mouseChildren:Boolean = false;
 		protected var _group:uint = 1;
 		protected var _view:*;
 		protected var _realDebugView:*;
@@ -149,6 +150,14 @@ package citrus.physics {
 
 		public function set touchable(value:Boolean):void {
 			_touchable = value;
+		}
+		
+		public function get mouseChildren() : Boolean {
+			return _mouseChildren;
+		}
+		
+		public function set mouseChildren(value:Boolean):void {
+			_mouseChildren = value;
 		}
 		
 		public function get animation():String {

--- a/src/citrus/view/starlingview/AnimationSequence.as
+++ b/src/citrus/view/starlingview/AnimationSequence.as
@@ -85,7 +85,7 @@ package citrus.view.starlingview {
 			_mcSequences[animation] = mc;
 			_mcSequences[animation].name = animation;
 			_mcSequences[animation].addEventListener(Event.COMPLETE, _animationComplete);
-			_mcSequences[animation].smoothing = _smoothing;
+			_mcSequences[animation].textureSmoothing = _smoothing;
 			_mcSequences[animation].fps = _animFps;
 		}
 
@@ -106,7 +106,7 @@ package citrus.view.starlingview {
 
 				_mcSequences[animation].name = animation;
 				_mcSequences[animation].addEventListener(Event.COMPLETE, _animationComplete);
-				_mcSequences[animation].smoothing = _smoothing;
+				_mcSequences[animation].textureSmoothing = _smoothing;
 			}
 		}
 


### PR DESCRIPTION
those classes extends from CitrusSprite class,but CitrusSprite just has one param,so  
update
super(name,params); ==>super(params); 