### PR TITLE
ObjectMakerStarling: child.name bugfix

### DIFF
--- a/src/citrus/utils/objectmakers/ObjectMakerStarling.as
+++ b/src/citrus/utils/objectmakers/ObjectMakerStarling.as
@@ -84,6 +84,9 @@ package citrus.utils.objectmakers {
 					if (child.params)
 						params = child.params;
 					
+					if (child.name)
+						params.name = child.name;
+					
 					params.x = child.x;
 					params.y = child.y;
 					


### PR DESCRIPTION
child.name is copied to params.name before CitrusObject creation, so it can be accessed by StarlingScene.getObjectByName(); (Bug fix, as child.name can no longer be passed as an augment when creating CitrusObject)